### PR TITLE
Added a new Trait which allows to deal with Validator Constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,45 @@ class MyCoolTest extends WebTestCase
 }
 ```
 
+## WithValidatorAssertionsTrait : Verify Validation Constraints after a request
+
+With this trait, you gain assertions methods which deal with Validation Constraints (requires WithClientTrait).
+
+```php
+<?php
+
+use Liior\SymfonyTestHelpers\Concerns\WithClientTrait;
+use Liior\SymfonyTestHelpers\Concerns\WithValidatorAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class MyCoolTest extends WebTestCase
+{
+    use WithClientTrait;
+    use WithValidatorAssertionsTrait;
+
+    public function testItRuns()
+    {
+        $this->initializeClient();
+
+        // Don't forget to enable profiler before your request or none of this will work !
+        $this->client->enableProfiler();
+
+        $this->post('/save', [
+            'firstName' => '', // It should create a violation
+            'lastName' => 'Dupont', // It should not
+            'age' => 2000 // It should create a violation
+        ]);
+
+        // You can do some assertions about the validator's violations list
+        $this->assertNoValidatorErrors(); // Will fail
+        $this->assertValidatorErrorsCount(2); // Will succeed
+        $this->assertValidatorHasError('firstName'); // Will succeed
+        $this->assertValidatorHasErrors(['firstName', 'age']); // Will succeed
+        $this->assertValidatorHasErrors(['firstName', 'lastName']); // Will fail (since lastName did not violate a constraint)
+    }
+}
+```
+
 ## WithFakerTrait: Using faker made easy
 
 With this trait, you gain access to faker.

--- a/src/Concerns/WithValidatorAssertionsTrait.php
+++ b/src/Concerns/WithValidatorAssertionsTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Liior\SymfonyTestHelpers\Concerns;
+
+use Liior\SymfonyTestHelpers\Exception\ProfilerNotEnabledException;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+trait WithValidatorAssertionsTrait
+{
+    /** 
+     * Asserts that not validations error occured 
+     */
+    public function assertNoValidatorErrors(): self
+    {
+        return $this->assertValidatorErrorsCount(0);
+    }
+
+    /** 
+     * Asserts that a specific number of errors occured in the validation process
+     */
+    public function assertValidatorErrorsCount(int $count): self
+    {
+        $violations = $this->getViolationsCount($this->getProfile());
+
+        $this->assertEquals($count, $violations, sprintf('Failed asserting that validator had %s errors, %s found !', $count, $violations));
+
+        return $this;
+    }
+
+    /** 
+     * Asserts that the validator found an error for the specified propertyPath 
+     */
+    public function assertValidatorHasError(string $propertyPath): self
+    {
+        $violations = $this->createConstraintsViolationsArray($this->getProfile());
+
+        $this->assertArrayHasKey(
+            $propertyPath,
+            $violations,
+            sprintf('Failed asserting that "%s" has a validation error', $propertyPath)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the validator found a set of errors for the specified properties
+     */
+    public function assertValidatorHasErrors(array $properties): self
+    {
+        $violations = $this->createConstraintsViolationsArray($this->getProfile());
+
+        $notExistingProperties = [];
+
+        foreach ($properties as $propertyPath) {
+            if (!array_key_exists($propertyPath, $violations)) {
+                $notExistingProperties[] = $propertyPath;
+            }
+        }
+
+        $this->assertEquals(
+            0,
+            count($notExistingProperties),
+            sprintf('Failed asserting that validator has these validation errors : %s', join(', ', $notExistingProperties))
+        );
+
+        return $this;
+    }
+
+    protected function getViolationsCount(Profile $profile): int
+    {
+        return $profile->getCollector('validator')->getViolationsCount();
+    }
+
+    protected function createConstraintsViolationsArray(Profile $profile): array
+    {
+        $calls = $profile->getCollector('validator')->getCalls();
+
+        $violations = [];
+
+        foreach ($calls as $call) {
+            foreach ($call->violations as $violation) {
+                $propertyPath = str_replace('data.', '', $violation->propertyPath);
+                $violations[$propertyPath] = $violation->message;
+            }
+        }
+
+        return $violations;
+    }
+
+    protected function getProfile(): Profile
+    {
+        $profile = $this->client->getProfile();
+
+        if (!$profile) {
+            throw new ProfilerNotEnabledException();
+        }
+
+        return $profile;
+    }
+}

--- a/src/Exception/ProfilerNotEnabledException.php
+++ b/src/Exception/ProfilerNotEnabledException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Liior\SymfonyTestHelpers\Exception;
+
+use RuntimeException;
+
+class ProfilerNotEnabledException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(\sprintf(
+            'Profiler was not initialized thus you should not call Validator assertions. Did you forget to call "%s" first?',
+            '$client->enableProfiler()'
+        ));
+    }
+}

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -8,6 +8,7 @@ use Liior\SymfonyTestHelpers\Concerns\WithDatabaseTrait;
 use Liior\SymfonyTestHelpers\Concerns\WithFakerTrait;
 use Liior\SymfonyTestHelpers\Concerns\WithClientTrait;
 use Liior\SymfonyTestHelpers\Concerns\WithContainerTrait;
+use Liior\SymfonyTestHelpers\Concerns\WithValidatorAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 
 class WebTestCase extends BaseWebTestCase
@@ -18,4 +19,5 @@ class WebTestCase extends BaseWebTestCase
     use WithClientTrait;
     use WithDatabaseTrait;
     use WithFakerTrait;
+    use WithValidatorAssertionsTrait;
 }


### PR DESCRIPTION
I felt there was no solution to see why a form would fail or not while testing a POST or a PUT Request, and I also wanted to test validation in a functional way (in a sense that it was a controller TestCase, not a simple entity validation test).

So I made this up : we use the profiler before the POST / PUT request, so after the request we can use informations collected by the validator component to assert anything we want about violations :)

Let me know what you think about that :)